### PR TITLE
Update to GBDK Version 4.0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Container image that runs your code
 FROM gcc
 
-ADD https://github.com/gbdk-2020/gbdk-2020/releases/download/4.0.5/gbdk-linux64.tar.gz /usr/lib/gbd.tar.gz
+ADD https://github.com/gbdk-2020/gbdk-2020/releases/download/4.0.6/gbdk-linux64.tar.gz /usr/lib/gbd.tar.gz
 RUN tar -xvf /usr/lib/gbd.tar.gz -C /usr/lib/
 
 WORKDIR /github/workspace

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # GBDK GitHub Action Builder
 
+<a href="https://github.com/gbdk-2020/gbdk-2020"><img src="https://img.shields.io/badge/GBDK--Version-4.0.6-brightgreen" /></a>
 ![Example Workflow](https://github.com/wujood/gbdk-2020-github-builder/workflows/Example%20Workflow/badge.svg)
 
 This action builds [gbdk-2020](https://github.com/gbdk-2020/gbdk-2020) projects with gcc.


### PR DESCRIPTION
## Changes
- Updates the used version to 4.0.6. 
- Introduces the version badge inside the README, since there was no direct indication of the version that is beeing used.